### PR TITLE
fix: replace shutdown hack with http.Server.Shutdown()

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -16,15 +16,14 @@ tmp_dir = "tmp"
   include_dir = []
   include_ext = ["go", "tpl", "tmpl", "templ", "html", "scss", "js", "md", "woff2"] 
   include_file = []
-  kill_delay = "0s"
+  kill_delay = "5s"
   log = "build-errors.log"
   poll = false
   poll_interval = 0
   rerun = false
   rerun_delay = 500
-  send_interrupt = false
+  send_interrupt = true
   stop_on_error = false
-  post_cmd = ["kill -15 $(lsof -ti:8080)"]
 
 [color]
   app = ""

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,8 +46,9 @@ func init() {
 }
 
 func main() {
-	ctx, cancel := signal.NotifyContext(
+	ctx, stop := signal.NotifyContext(
 		context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	// Check if the SERVER_HOST env var is set and override
 	envHost, ok := os.LookupEnv("SERVER_HOST")
@@ -78,27 +79,26 @@ func main() {
 	// Wrap mux with CSP middleware
 	handler := middleware.CSP(mux)
 
-	// Run the server at
+	// Run the server
 	serveAt := fmt.Sprintf("%s:%s", serverHost, serverPort)
+	srv := http.Server{Addr: serveAt, Handler: handler}
 	go func() {
-		if err := http.ListenAndServe(serveAt, handler); err != nil {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatal(err)
 		}
 	}()
 
 	logger.Info("API Server available", "addr", serveAt)
 
-	// Wait for interrupt signal.
+	// Wait for interrupt signal, then gracefully shut down
 	<-ctx.Done()
-
-	// Sleep to ensure graceful shutdown
-	logger.Info("Server shutting down...")
-	time.Sleep(5 * time.Second)
-
-	// Return to default context.
-	cancel()
-
-	logger.Info("Server stopped")
+	logger.Info("shutting down")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("forced shutdown", "error", err)
+	}
+	logger.Info("server stopped")
 }
 
 func registerHandlers(mux *http.ServeMux) {


### PR DESCRIPTION
Replaces the `time.Sleep(5s)` hack with proper `http.Server.Shutdown()` using a 10-second deadline context, matching the pattern from obsidian-remote. Also renames `cancel` → `stop` with deferred cleanup.