### PR TITLE
feat: URL param sharing for chart tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,7 +379,7 @@ Detailed explanation of the metric, calculation method, and data sources.
 The handler must:
 
 1. Parse `range` query param (default: "max", options: "1y", "5y", "10y", "20y", "50y")
-2. Parse `quartiles` query param (present = true, absent = false)
+2. Parse overlay query param using `r.URL.Query().Get("quartiles") == "on"` (or `"average"`). Returns true when param is `"on"`, false for `"off"` or absent.
 3. Use `internal/charts.CalculateRangeStart(rangeParam)` to get start date
 4. Use `internal/fred.FetchSeries(seriesID, opts)` to fetch FRED data
 5. Convert to `LineChartData` format
@@ -406,7 +406,7 @@ func MyChartHandler(w http.ResponseWriter, r *http.Request) {
 	if rangeParam == "" {
 		rangeParam = "max"
 	}
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	// 2. Fetch data (implement your data fetching logic)
 	data := fetchMyData(rangeParam, showQuartiles)
@@ -477,7 +477,7 @@ func MyChartHandler(w http.ResponseWriter, r *http.Request) {
 	if rangeParam == "" {
 		rangeParam = "max"
 	}
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	// Generate cache key
 	cacheKey := fmt.Sprintf("mychart:%s:%v", rangeParam, showQuartiles)
@@ -541,7 +541,7 @@ Copy this template exactly from `layouts/tools/msindex.html`. The layout is enti
               hx-target="#chart-inner"
               hx-include="[name=quartiles]"
               hx-swap="innerHTML"
-              hx-trigger="load, change"
+              hx-trigger="load delay:200ms, change"
             />
             Max
           </label>
@@ -641,7 +641,7 @@ func MyChartDownloadsHandler(w http.ResponseWriter, r *http.Request) {
 	if rangeParam == "" {
 		rangeParam = "max"
 	}
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	// Use the reusable templ component - just pass your tool name
 	component := templates.ChartDownloads("[tool-name]", rangeParam, showQuartiles)
@@ -782,6 +782,7 @@ Example output:
 ✅ **Chart destruction/recreation** – Handles HTMX swaps correctly  
 ✅ **Responsive design** – Works on mobile and desktop  
 ✅ **CSP compliant** – No inline scripts, all JS external
+✅ **URL param sharing** – Controls sync to browser URL via `chart-shareable.js`, loaded in `chart-scripts.html` partial. URLs like `/tools/msindex/?range=5y&quartiles=on` restore chart state on load. Overlay params use explicit `on`/`off` values (not just presence/absence), and Go handlers check `r.URL.Query().Get("param") == "on"`.
 
 ---
 

--- a/assets/js/chart-shareable.js
+++ b/assets/js/chart-shareable.js
@@ -1,0 +1,91 @@
+/**
+ * Chart Shareable — Syncs chart control state with URL query params.
+ * On load with URL params: overrides HTML defaults, triggers chart reload,
+ *   and prevents the HTML load trigger from firing with stale defaults.
+ * On user change: writes current control state to the browser URL.
+ */
+(function () {
+  var CONTROLS_SELECTOR = ".chart-controls input";
+  var suppressLoad = false;
+
+  function getControls() {
+    return document.querySelectorAll(CONTROLS_SELECTOR);
+  }
+
+  function readURL() {
+    var params = new URLSearchParams(window.location.search);
+    if (window.location.search.length === 0) return false;
+
+    getControls().forEach(function (input) {
+      if (input.type === "radio") {
+        input.checked = params.get(input.name) === input.value;
+      } else if (input.type === "checkbox") {
+        input.checked = params.get(input.name) === "on";
+      }
+    });
+
+    return true;
+  }
+
+  function writeURL() {
+    var url = new URL(window.location);
+
+    getControls().forEach(function (input) {
+      if (input.type === "radio") {
+        if (input.checked) url.searchParams.set(input.name, input.value);
+      } else if (input.type === "checkbox") {
+        if (input.checked) {
+          url.searchParams.set(input.name, "on");
+        } else {
+          url.searchParams.set(input.name, "off");
+        }
+      }
+    });
+
+    window.history.replaceState({}, "", url);
+  }
+
+  document.body.addEventListener("htmx:beforeRequest", function (evt) {
+    if (!suppressLoad) return;
+    if (
+      evt.detail.requestConfig &&
+      evt.detail.requestConfig.trigger &&
+      evt.detail.requestConfig.trigger === "load"
+    ) {
+      evt.preventDefault();
+      suppressLoad = false;
+    }
+  });
+
+  function init() {
+    var controls = getControls();
+    if (controls.length === 0) return;
+
+    if (readURL()) {
+      suppressLoad = true;
+      var radio = document.querySelector(
+        '.chart-controls input[type="radio"]:checked'
+      );
+      if (radio && window.htmx) htmx.trigger(radio, "change");
+    }
+
+    controls.forEach(function (input) {
+      input.addEventListener("change", writeURL);
+    });
+
+    window.addEventListener("popstate", function () {
+      if (readURL()) {
+        var radio = document.querySelector(
+          '.chart-controls input[type="radio"]:checked'
+        );
+        if (radio && window.htmx) htmx.trigger(radio, "change");
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/internal/handlers/buffett-indicator.go
+++ b/internal/handlers/buffett-indicator.go
@@ -147,7 +147,7 @@ func BuffettIndicatorHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	chartData, err := getOrFetchBuffetData(rangeParam, showAverage)
 	if err != nil {
@@ -198,7 +198,7 @@ func BuffettIndicatorDownloadsHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	component := templates.ChartDownloads("buffett-indicator", rangeParam, "average", showAverage)
 
@@ -227,7 +227,7 @@ func BuffettIndicatorCSVHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	chartData, err := getOrFetchBuffetData(rangeParam, showAverage)
 	if err != nil {
@@ -278,7 +278,7 @@ func BuffettIndicatorDataHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	chartData, err := getOrFetchBuffetData(rangeParam, showAverage)
 	if err != nil {

--- a/internal/handlers/msindex.go
+++ b/internal/handlers/msindex.go
@@ -116,7 +116,7 @@ func MSIndexDownloadsHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	component := templates.ChartDownloads("msindex", rangeParam, "quartiles", showQuartiles)
 
@@ -145,7 +145,7 @@ func MSIndexCSVHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	chartData, err := getOrFetchChartData(rangeParam, showQuartiles)
 	if err != nil {
@@ -196,7 +196,7 @@ func MSIndexDataHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	chartData, err := getOrFetchChartData(rangeParam, showQuartiles)
 	if err != nil {
@@ -223,7 +223,7 @@ func MSIndexHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showQuartiles := r.URL.Query().Has("quartiles")
+	showQuartiles := r.URL.Query().Get("quartiles") == "on"
 
 	chartData, err := getOrFetchChartData(rangeParam, showQuartiles)
 	if err != nil {

--- a/internal/handlers/real-interest-rate.go
+++ b/internal/handlers/real-interest-rate.go
@@ -146,7 +146,7 @@ func RealInterestRateHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	chartData, err := getOrFetchRealRateData(rangeParam, showAverage)
 	if err != nil {
@@ -196,7 +196,7 @@ func RealInterestRateDownloadsHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	component := templates.ChartDownloads("real-interest-rate", rangeParam, "average", showAverage)
 
@@ -225,7 +225,7 @@ func RealInterestRateCSVHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	chartData, err := getOrFetchRealRateData(rangeParam, showAverage)
 	if err != nil {
@@ -276,7 +276,7 @@ func RealInterestRateDataHandler(w http.ResponseWriter, r *http.Request) {
 		rangeParam = "max"
 	}
 
-	showAverage := r.URL.Query().Has("average")
+	showAverage := r.URL.Query().Get("average") == "on"
 
 	chartData, err := getOrFetchRealRateData(rangeParam, showAverage)
 	if err != nil {

--- a/layouts/partials/chart-scripts.html
+++ b/layouts/partials/chart-scripts.html
@@ -5,9 +5,15 @@
   crossorigin="anonymous"
   defer
 ></script>
-{{ $script := resources.Get "js/chart-init.js" | minify | fingerprint "sha384" }}
+{{ $chartInit := resources.Get "js/chart-init.js" | minify | fingerprint "sha384" }}
 <script
-  src="{{ $script.RelPermalink }}"
-  integrity="{{ $script.Data.Integrity }}"
+  src="{{ $chartInit.RelPermalink }}"
+  integrity="{{ $chartInit.Data.Integrity }}"
+  defer
+></script>
+{{ $chartShareable := resources.Get "js/chart-shareable.js" | minify | fingerprint "sha384" }}
+<script
+  src="{{ $chartShareable.RelPermalink }}"
+  integrity="{{ $chartShareable.Data.Integrity }}"
   defer
 ></script>


### PR DESCRIPTION
Chart controls (range radios and overlay checkboxes) now sync with browser URL params. Users can share URLs like `/tools/msindex/?range=5y&quartiles=on` and the chart will restore that state on load.